### PR TITLE
Fix pe/follow-current-open when not in project buffer

### DIFF
--- a/project-explorer.el
+++ b/project-explorer.el
@@ -1760,8 +1760,10 @@ If project-explorer isn't opened or no project associated with
 the current buffer, stop following."
   (if pe/follow-current
       (when (and (pe/get-project-explorer-window)
-                 (or (pe/get-current-project-explorer-buffer)
-                     (pe/has-cache-p)))
+                 (if (fboundp 'projectile-project-p)
+                     (projectile-project-p)
+                   (or (pe/get-current-project-explorer-buffer)
+                       (pe/has-cache-p))))
         (let ((win (selected-window)))
           (project-explorer-open)
           (select-window win)))


### PR DESCRIPTION
When  `pe/follow-current` is set to `t`, if you visit any buffer that is not in a project and you have projectile installed, `pe/follow-current-open` displays an error in the minibuffer every time the timer function is run...

```
Error running timer `pe/follow-current-open': (error "You're not in a project") [56 times]
```

The error comes from Projectile when it is called with the default project root command on [line 292 of project-explorer.el](https://github.com/sabof/project-explorer/blob/589a09008706f5f4ef91393dc4306eede0d15ca9/project-explorer.el#L292).

This pull request makes the timer function only try to follow the current project if we are in one.

The reason I changed `pe/follow-current-open` and not `pe/project-root-function-default` is because `pe/follow-current-open` appears to be the only location  where this error isn't useful, and the projectile command can short-circut the logic in project-explorer so that it will be slightly more future-proof.
